### PR TITLE
for Etsy, populate `uid` with `shop_id`

### DIFF
--- a/lib/omniauth/strategies/etsy.rb
+++ b/lib/omniauth/strategies/etsy.rb
@@ -22,7 +22,9 @@ module OmniAuth
           'first_name' => profile_info['first_name'],
           'last_name' => profile_info['last_name'],
           'image' => profile_info['image_url_75x75'],
-          'profile' => profile_info
+          'profile' => profile_info,
+          'shop_id' => shop['shop_id'],
+          'shop_name' => shop['shop_name']
         }
       end
 
@@ -61,6 +63,13 @@ module OmniAuth
         raise ::Timeout::Error
       rescue ::OAuth::Error => e
         raise e.response.inspect
+      end
+
+      def shop
+        # while the api allows multiple shops per user, the UI seems to support
+        # only one shop per user; grabbing first record
+        shops = MultiJson.decode(@access_token.get('/shops/__SELF__?includes=Profile').body)['results']
+        shops[0]
       end
 
     end

--- a/lib/omniauth/strategies/etsy.rb
+++ b/lib/omniauth/strategies/etsy.rb
@@ -11,7 +11,8 @@ module OmniAuth
         :authorize_url      => "https://www.etsy.com/oauth/signin"
       }
 
-      uid { user_hash['user_id'] }
+      # ShippingEasy relies on shop_id, rather than user_id, as an external id
+      uid { shop['shop_id'] }
 
       info do
         {
@@ -22,9 +23,7 @@ module OmniAuth
           'first_name' => profile_info['first_name'],
           'last_name' => profile_info['last_name'],
           'image' => profile_info['image_url_75x75'],
-          'profile' => profile_info,
-          'shop_id' => shop['shop_id'],
-          'shop_name' => shop['shop_name']
+          'profile' => profile_info
         }
       end
 


### PR DESCRIPTION
ShippingEasy expects the `shop_id` for `uid`. This change replaces in `user_id` with `shop_id`

`user_id`, if needed, is still stored in the `auth_hash` as `user_id` (it was redundant previously)

This change will likely not be proposed to the actual gem, since it is logic very specific to us.  
