### PR TITLE
Store data not always present

### DIFF
--- a/lib/omniauth/strategies/etsy.rb
+++ b/lib/omniauth/strategies/etsy.rb
@@ -76,11 +76,14 @@ module OmniAuth
         # while the api allows multiple shops per user, the UI seems to support
         # only one shop per user; grabbing first record
         # https://www.etsy.com/developers/documentation/reference/shop#method_findallusershops
-        user_id = raw_info['user_id']
-        response = @access_token.get("/users/#{user_id}/shops")
+        response = @access_token.get('/users/__SELF__/shops')
         return unless response && response.code.to_s != '404'
-        shops = MultiJson.decode(response.body)['results']
-        shops.first
+        begin
+          shops = MultiJson.decode(response.body)['results']
+          shops.first
+        rescue # In the case the user has no shop/response is invalid
+          nil
+        end
       end
     end
   end


### PR DESCRIPTION
#### Related Honeybadger error

https://app.honeybadger.io/projects/34097/faults/26928380
#### Summary

The overall goal is to allow shop_id to be nil if necessary (see discussion below!)
- a check to the response -- don't do anything with 404s, which seems to be the nature of the related HB error, since the error notes 'is not a valid shop_id' (I could never duplicate it exactly, but did get some related parsing errors like `MultiJson::LoadError: 795: unexpected token at 'Shop with PK shop_id = 72484 does not exist`)
- `/shops/__SELF__` was a [potentially invalid call](https://groups.google.com/d/msg/etsy-api-v2/cOm_jKm0_PE/oSauGvEN8iQJ), changed to `/users/__SELF__/shops`
- if something blows up in the JSON parsing stage, just return nil. This is pretty loose, but scoped to just `MultiJson.decode` (and the `.first` on the results of that call)
##### Discussion/Details

In the previous implementation within ship-it, it looks like we would have encountered a different (and commonly seen) error if something went wrong getting the shop_id:

```
> ::Etsy.user('somebaduserid').shop
Etsy::EtsyJSONInvalid: Etsy::EtsyJSONInvalid
```

But that it was certainly also possible to return nil if the user did not have a shop:

```
> Etsy.user('2222').shop
nil
```

The code we used can be found [here](https://github.com/ShippingEasy/ship-it/blob/2f727526fd95268ead7e0e23f2c0675ed64a1c3e/app/controllers/oauth/etsy_verifications_controller.rb#L32-L35). It called `Etsy.myself`, so varies slightly from the example above, but `Etsy.myself` is the current user record.

Further, the Etsy gem supports that a user may not always return a shop in an explicit comment:
`# Represents a single Etsy shop.  Users may or may not have an associated shop.`
https://github.com/kytrinyx/etsy/blob/master/lib/etsy/shop.rb#L5

So I think we are okay continuing to allow a `nil` result for `shop_id`.
